### PR TITLE
Fix issue #2. 

### DIFF
--- a/index.php
+++ b/index.php
@@ -60,7 +60,7 @@
 		
 		<h1><?php include 'demo/modaal-logo.php' ?><span class="ui-hidden">Modaal</span></h1>
 		<p>An accessible dialog window plugin for all humans.</p>
-		<a href="https://github.com/humaan/Modaal" target="_blank" class="btn btn-download">Download from Github<?php/* <span><strong>19kb</strong></span>*/ ?></a>
+		<a href="https://github.com/humaan/Modaal" target="_blank" class="btn btn-download">Download from Github<?php /* <span><strong>19kb</strong></span>*/ ?></a>
 		<a href="#inline-content" class="btn modaal main-example" data-modaal-type="inline">View Example</a>
 		<div class="version" aria-label="Version 0.2.9">v0.2.9</div>
 		<a href="http://www.humaan.com" target="_blank" class="humaan-project">A Humaan project</a>

--- a/source/js/modaal.js
+++ b/source/js/modaal.js
@@ -158,7 +158,7 @@
 						break;
 				}
 				
-				// call events to be watched (click, tab, keyup etc.)
+				// call events to be watched (click, tab, keyup, keydown etc.)
 				self.watch_events();
 				
 			});
@@ -175,8 +175,22 @@
 		watch_events : function() {
 			var self = this;
 			
-			dom.off('click.Modaal keyup.Modaal');
-			
+			dom.off('click.Modaal keyup.Modaal keydown.Modaal');
+
+            // Body keydown
+            dom.bind('keydown.Modaal', function(e) {
+                var key = e.keyCode;
+                var target = e.target;
+
+                // look for tab change and reset focus to modal window
+                // done in keydown so the check fires repeatedly when you hold the tab key down
+                if (key == 9 && self.scope.is_open) {
+                    if (!$.contains(document.getElementById(self.scope.id), target) ) {
+                        $('#' + self.scope.id).find('*[tabindex="0"]').focus();
+                    }
+                }
+            });
+
 			// Body keyup
 			dom.bind('keyup.Modaal', function(e) {
 				var key = e.keyCode;
@@ -205,13 +219,6 @@
 						self.gallery_update('next');
 					}
 					return;
-				}
-
-				// look for tab change and reset focus to modal window
-				if (key == 9 && self.scope.is_open) {
-					if (!$.contains(document.getElementById(self.scope.id), target) ) {
-						$('#' + self.scope.id).find('*[tabindex="0"]').focus();
-					}
 				}
 			});
 


### PR DESCRIPTION
Check for when focus escapes modal moved from keyup to keydown, which fires repeatedly when tab is help (keyup doesn't).